### PR TITLE
Add course concept and mission import

### DIFF
--- a/SCHACH_KURS_KONZEPT.md
+++ b/SCHACH_KURS_KONZEPT.md
@@ -1,0 +1,45 @@
+# User Story: Vater-Tochter-Schachkurs
+
+## Zielgruppe
+- Vater (Erwachsener mit Grundkenntnissen)
+- Tochter (Kind, kompletter Anfänger)
+
+## Kursidee
+Der Kurs vermittelt spielerisch die Grundlagen des Schachs und führt später in einfach verständliche Strategien ein. Beide lernen gemeinsam, wobei Missionsfortschritte getrennt gespeichert werden können. 
+
+## Struktur des Kurses
+- **Tracks** gruppieren Missionen thematisch.
+- Zwei Haupttracks werden bereitgestellt:
+  1. **Einsteiger** – kindgerechte Einführung in Regeln und Grundzüge.
+  2. **Strategie 101** – einfache Strategiekonzepte für den Erwachsenen.
+- Jede Mission erklärt ein konkretes Ziel (z.B. "Ziehe den Bauern"), zeigt ein Startbrett und überprüft den Zug.
+
+## Beispiel-Track "Einsteiger"
+1. Das Schachbrett kennenlernen
+2. Bauern ziehen
+3. Türme bewegen
+4. Läufer bewegen
+5. Springer-Sprung
+
+## Beispiel-Track "Strategie 101"
+1. Zentrumskontrolle
+2. Figurenentwicklung
+3. Kurze Rochade
+4. Doppeldrohung
+5. Fesselung anwenden
+
+## Interaktive Game-UI
+- Drag-und-Drop-Schachbrett mit einfachen Animationen.
+- Fortschrittsanzeige in Sternen pro Mission.
+- Tipp-Funktion und gesprochene Anweisungen für Kinder.
+- Missionsauswahlbildschirm mit Karten für jeden Track.
+- Möglichkeit, über einen **Import**-Button neue Tracks/Missionen als JSON hochzuladen.
+
+## Implementierungsplan (Auszug)
+1. Missions- und Trackdaten als JSON-Struktur definieren (`js/missions`).
+2. In `mission-manager.js` Importfunktionen bereitstellen, um neue Daten zu laden.
+3. In `main.js` Datei-Upload verarbeiten und Missionen anzeigen.
+4. UI-Elemente in `index.html` ergänzen (Import-Button).
+5. Später: Fortschrittsverwaltung je Benutzer, evtl. Exportfunktion.
+
+Mit diesem Konzept kann der Kurs Schritt für Schritt erweitert werden und bleibt dank des JSON-Formats leicht anpassbar.

--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
             <nav class="main-nav">
                 <button id="missions-btn" class="nav-btn active">Missionen</button>
                 <button id="progress-btn" class="nav-btn">Fortschritt</button>
+                <button id="import-btn" class="nav-btn">Import</button>
+                <input id="import-input" type="file" accept="application/json" class="hidden" />
             </nav>
         </header>
 

--- a/js/main.js
+++ b/js/main.js
@@ -52,6 +52,8 @@ class MissionSchachApp {
     initializeEventListeners() {
         const missionsBtn = document.getElementById('missions-btn');
         const progressBtn = document.getElementById('progress-btn');
+        const importBtn = document.getElementById('import-btn');
+        const importInput = document.getElementById('import-input');
         const backBtn = document.getElementById('back-btn');
         const homeBtn = document.getElementById('home-btn');
         const homeProgressBtn = document.getElementById('home-progress-btn');
@@ -65,6 +67,17 @@ class MissionSchachApp {
             this.showScreen('progress-screen');
             this.setActiveNavButton('progress-btn');
         });
+
+        if (importBtn && importInput) {
+            importBtn.addEventListener('click', () => importInput.click());
+            importInput.addEventListener('change', (e) => {
+                const file = e.target.files[0];
+                if (file) {
+                    this.importTrackFile(file);
+                    importInput.value = '';
+                }
+            });
+        }
 
         if (backBtn) backBtn.addEventListener('click', () => {
             this.showScreen('mission-select');
@@ -220,13 +233,34 @@ class MissionSchachApp {
             this.setActiveNavButton('missions-btn');
         }
     }
-	
-	await this.initializeMissions();
-	this.showScreen('mission-select');
-	this.initializeUI();
-	this.initializeEventListeners();
-	await this.loadScreenContent('mission-select'); // ← direkt laden!
 
+    async importTrackFile(file) {
+        try {
+            const text = await file.text();
+            const data = JSON.parse(text);
+
+            let tracks = [];
+            if (Array.isArray(data)) {
+                tracks = data;
+            } else if (data.tracks) {
+                tracks = data.tracks;
+            } else if (data.id) {
+                tracks = [data];
+            }
+
+            if (tracks.length > 0 && window.missionManager) {
+                window.missionManager.importTracks(tracks);
+                this.loadScreenContent('mission-select');
+                this.showSuccess('Import erfolgreich', `${tracks.length} Track(s) importiert.`);
+            } else {
+                this.showError('Import fehlgeschlagen', 'Ungültiges Format.');
+            }
+        } catch (error) {
+            console.error('Import error:', error);
+            this.showError('Import fehlgeschlagen', error.message);
+        }
+    }
+	
 }
 
 const app = new MissionSchachApp();

--- a/js/mission-manager.js
+++ b/js/mission-manager.js
@@ -58,14 +58,39 @@ export class MissionManager {
         }
         return all;
     }
-	
-	loadMission(missionId) {
-		for (const track of this.tracks) {
-			const list = this.missions[track.id] || [];
-			const mission = list.find(m => m.id === missionId);
-			if (mission) return mission;
-		}
-		return null;
-	}
+
+    importTrack(track) {
+        if (!track || !track.id) return;
+
+        const existing = this.tracks.find(t => t.id === track.id);
+        if (!existing) {
+            this.tracks.push({
+                id: track.id,
+                title: track.title,
+                description: track.description,
+                file: track.file || null
+            });
+        }
+
+        if (track.missions) {
+            this.missions[track.id] = track.missions;
+        }
+    }
+
+    importTracks(trackArray) {
+        if (!Array.isArray(trackArray)) return;
+        for (const t of trackArray) {
+            this.importTrack(t);
+        }
+    }
+
+    loadMission(missionId) {
+        for (const track of this.tracks) {
+            const list = this.missions[track.id] || [];
+            const mission = list.find(m => m.id === missionId);
+            if (mission) return mission;
+        }
+        return null;
+    }
 
 }


### PR DESCRIPTION
## Summary
- add SCHACH_KURS_KONZEPT.md with user story and plan
- implement JSON import for tracks and missions
- expose import button and file input in the UI

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_687e6efc3a7883289b9f101d2ae3c57c