### PR TITLE
Fix mission loading and add track selection screen

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -142,6 +142,29 @@ body {
     margin-top: var(--spacing-lg);
 }
 
+/* Track Grid */
+.track-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: var(--spacing-lg);
+    margin-top: var(--spacing-lg);
+}
+
+.track-card {
+    background: white;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+    cursor: pointer;
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+    padding: var(--spacing-md);
+}
+
+.track-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+}
+
 .mission-card {
     background: white;
     border-radius: var(--radius-lg);
@@ -651,6 +674,10 @@ body {
     }
     
     .mission-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .track-grid {
         grid-template-columns: 1fr;
     }
     

--- a/index.html
+++ b/index.html
@@ -29,8 +29,15 @@
         </header>
 
         <main class="app-main">
+            <!-- Track Selection Screen -->
+            <section id="track-select" class="screen active">
+                <div class="track-grid" id="track-grid">
+                    <!-- Tracks will be loaded here -->
+                </div>
+            </section>
+
             <!-- Mission Selection Screen -->
-            <section id="mission-select" class="screen active">
+            <section id="mission-select" class="screen">
                 <div class="mission-grid" id="mission-grid">
                     <!-- Missions will be loaded here -->
                 </div>

--- a/js/mission-manager.js
+++ b/js/mission-manager.js
@@ -4,9 +4,13 @@ export class MissionManager {
         this.missions = {};
     }
 
-    async init() {
+    async init(preloadedTracks = null) {
         console.log('MissionManager initializing...');
-        await this.loadTracks();
+        if (Array.isArray(preloadedTracks)) {
+            this.importTracks(preloadedTracks);
+        } else {
+            await this.loadTracks();
+        }
         console.log('MissionManager ready.');
     }
 
@@ -39,19 +43,15 @@ export class MissionManager {
         return list.find(m => m.id === missionId);
     }
 
-    getMissionList() {
+    getMissionList(trackId = null) {
         const all = [];
 
-		
-        // Flatten all missions with track references
-		if (!Array.isArray(this.tracks)) return all;
-        
-		for (const track of this.tracks) {
-            //const list = this.missions[track.id] || [];
-			const list = Array.isArray(this.missions[track.id]) ? this.missions[track.id] : [];
+        if (!Array.isArray(this.tracks)) return all;
 
-			
-			console.log(list);
+        const tracks = trackId ? this.tracks.filter(t => t.id === trackId) : this.tracks;
+
+        for (const track of tracks) {
+            const list = Array.isArray(this.missions[track.id]) ? this.missions[track.id] : [];
             for (const m of list) {
                 all.push({ ...m, trackId: track.id });
             }
@@ -84,8 +84,9 @@ export class MissionManager {
         }
     }
 
-    loadMission(missionId) {
-        for (const track of this.tracks) {
+    loadMission(missionId, trackId = null) {
+        const tracks = trackId ? this.tracks.filter(t => t.id === trackId) : this.tracks;
+        for (const track of tracks) {
             const list = this.missions[track.id] || [];
             const mission = list.find(m => m.id === missionId);
             if (mission) return mission;


### PR DESCRIPTION
## Summary
- await track loading before showing screens
- add a new track selection screen and style
- filter mission list by current track
- allow returning to track overview from missions

## Testing
- `node --check js/main.js && node --check js/mission-manager.js`

------
https://chatgpt.com/codex/tasks/task_e_687e76dfc7a08328bc9274dd96b634b4