### PR TITLE
Fix mission handling and adjust strategy track

### DIFF
--- a/js/mission-manager.js
+++ b/js/mission-manager.js
@@ -22,11 +22,13 @@ export class MissionManager {
             this.tracks = data;
 
             // Load all missions per track
-			for (const track of this.tracks) {
-				const missionResponse = await fetch(`/js/missions/${track.file}`);
-				const missionData = await missionResponse.json();
-				this.missions[track.id] = missionData.missions; // ← WICHTIG
-			}
+            for (const track of this.tracks) {
+                const missionResponse = await fetch(`/js/missions/${track.file}`);
+                const missionData = await missionResponse.json();
+                this.missions[track.id] = Array.isArray(missionData.missions)
+                    ? missionData.missions.map(m => this.normalizeMission(m))
+                    : [];
+            }
 
         } catch (error) {
             console.error('Fehler beim Laden der Tracks:', error);
@@ -92,6 +94,15 @@ export class MissionManager {
             if (mission) return mission;
         }
         return null;
+    }
+
+    normalizeMission(mission) {
+        if (!mission) return {};
+        return {
+            ...mission,
+            instruction: mission.instruction || mission.objective || mission.description || '',
+            boardInitial: mission.boardInitial || mission.fen || mission.startFen || '8/8/8/8/8/8/8/8 w - - 0 1'
+        };
     }
 
 }

--- a/js/missions/strategy_track.json
+++ b/js/missions/strategy_track.json
@@ -101,7 +101,7 @@
           "behind": "K"
         }
       ],
-      "startFen": "rnbqk2r/pppp1ppp/5n2/4p3/4P3/2N2N2/PPPP1PPP/R1BQKB1R w KQkq - 4 4",
+      "startFen": "r1bqkb1r/pppp1ppp/2n2n2/4p3/4P3/2N2N2/PPPP1PPP/R1BQKB1R w KQkq - 4 4",
       "solution": [
         "f1b5"
       ],

--- a/js/ui.js
+++ b/js/ui.js
@@ -94,13 +94,38 @@ class UIController {
     updateMissionGoals(goals) {
         const goalsElement = document.getElementById('mission-goals');
         if (goalsElement && Array.isArray(goals)) {
-            goalsElement.innerHTML = goals.map(goal => 
-                `<div class="goal" data-goal="${goal}">
+            goalsElement.innerHTML = goals.map(goal => {
+                const text = this.formatGoal(goal);
+                return `<div class="goal" data-goal="${text}">
                     <span class="goal-icon">○</span>
-                    <span class="goal-text">${goal}</span>
-                </div>`
-            ).join('');
+                    <span class="goal-text">${text}</span>
+                </div>`;
+            }).join('');
         }
+    }
+
+    formatGoal(goal) {
+        if (typeof goal === 'string') return goal;
+
+        switch (goal.type) {
+            case 'position':
+                return `Bringe ${this.getPieceName(goal.piece)} nach ${goal.square}`;
+            case 'castle':
+                return goal.side === 'kingside' ? 'Rochiere kurz' : 'Rochiere lang';
+            case 'check':
+                return 'Setze den König schach';
+            case 'attack':
+                return `Greife eine ${this.getPieceName(goal.piece)} an`;
+            case 'pin':
+                return 'Fessele eine Figur';
+            default:
+                return JSON.stringify(goal);
+        }
+    }
+
+    getPieceName(piece) {
+        const map = { P: 'Bauer', N: 'Springer', B: 'L\xE4ufer', R: 'Turm', Q: 'Dame', K: 'K\xF6nig' };
+        return map[piece?.toUpperCase()] || 'Figur';
     }
 
     updateMissionScore(score, maxScore = 100) {


### PR DESCRIPTION
## Summary
- load mission files with consistent field names
- show objectives when instructions are missing
- support structured goals for mission evaluation
- correct FEN for strategy mission "s05"

## Testing
- `pip install python-chess` *(for manual board checks)*

------
https://chatgpt.com/codex/tasks/task_e_687e7c7b44188328a4745cb2b6ac5219