### PR TITLE
Add next mission navigation

### DIFF
--- a/js/mission-manager.js
+++ b/js/mission-manager.js
@@ -105,4 +105,27 @@ export class MissionManager {
         };
     }
 
+    getNextMissionId(currentMissionId, trackId = null) {
+        const missions = this.getMissionList(trackId);
+        const index = missions.findIndex(m => m.id === currentMissionId);
+        if (index >= 0 && index < missions.length - 1) {
+            return missions[index + 1].id;
+        }
+        return null;
+    }
+
+    async completeMission(missionId, score = 0, playTime = 0) {
+        if (typeof storage === 'undefined' || !missionId) return;
+
+        const stars = score >= 80 ? 3 : score >= 60 ? 2 : score >= 40 ? 1 : 0;
+        const progressData = {
+            status: 'completed',
+            score,
+            stars,
+            playTime
+        };
+
+        await storage.saveProgress(missionId, progressData);
+    }
+
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -363,9 +363,20 @@ class UIController {
     }
 
     goToNextMission() {
-        // Find next available mission
-        window.missionSchachApp.showScreen('mission-select');
-        window.missionSchachApp.setActiveNavButton('missions-btn');
+        const app = window.missionSchachApp;
+        const manager = window.missionManager;
+        if (!app || !manager) {
+            return;
+        }
+
+        const nextId = manager.getNextMissionId(app.currentMission, app.currentTrack);
+
+        if (nextId) {
+            app.startMission(nextId);
+        } else {
+            app.showScreen('mission-select');
+            app.setActiveNavButton('missions-btn');
+        }
     }
 
     // Error handling


### PR DESCRIPTION
## Summary
- implement progress completion API in MissionManager
- allow MissionManager to find the next mission
- update UI to start the next mission directly when pressing **Nächste Mission**

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e7f7cab8c8328ac1453e79fe7ba9b